### PR TITLE
added required @escaping attribute to function's attribute types

### DIFF
--- a/C4/UI/UIGestureRecognizer+Closure.swift
+++ b/C4/UI/UIGestureRecognizer+Closure.swift
@@ -90,7 +90,7 @@ extension UITapGestureRecognizer {
             }
         }
     }
-    internal convenience init(view: UIView, action: TapAction) {
+    internal convenience init(view: UIView, action: @escaping TapAction) {
         self.init()
         self.referenceView = view
         self.tapAction = action
@@ -98,7 +98,7 @@ extension UITapGestureRecognizer {
     /// This class is used as the target of the gesture recognizer action. It forwards the method call to the closure.
     internal class TapGestureHandler: NSObject {
         let action: TapAction
-            init(_ action: TapAction) {
+            init(_ action: @escaping TapAction) {
             self.action = action
         }
         func handleGesture(_ gestureRecognizer: UIPanGestureRecognizer) {
@@ -154,7 +154,7 @@ extension UIPanGestureRecognizer {
         }
     }
 
-    internal convenience init(view: UIView, action: PanAction) {
+    internal convenience init(view: UIView, action: @escaping PanAction) {
         self.init()
         self.referenceView = view
         self.panAction = action
@@ -162,7 +162,7 @@ extension UIPanGestureRecognizer {
     /// This class is used as the target of the gesture recognizer action. It forwards the method call to the closure.
     internal class PanGestureHandler: NSObject {
         let action: PanAction
-            init(_ action: PanAction) {
+            init(_ action: @escaping PanAction) {
             self.action = action
         }
         func handleGesture(_ gestureRecognizer: UIPanGestureRecognizer) {
@@ -196,7 +196,7 @@ extension UIPinchGestureRecognizer {
             }
         }
     }
-    internal convenience init(view: UIView, action: PinchAction) {
+    internal convenience init(view: UIView, action: @escaping PinchAction) {
         self.init()
         self.referenceView = view
         self.pinchAction = action
@@ -204,7 +204,7 @@ extension UIPinchGestureRecognizer {
     /// This class is used as the target of the gesture recognizer action. It forwards the method call to the closure.
     internal class PinchGestureHandler: NSObject {
         let action: PinchAction
-            init(_ action: PinchAction) {
+            init(_ action: @escaping PinchAction) {
             self.action = action
         }
         func handleGesture(_ gestureRecognizer: UIPinchGestureRecognizer) {
@@ -238,7 +238,7 @@ extension UIRotationGestureRecognizer {
             }
         }
     }
-    internal convenience init(view: UIView, action: RotationAction) {
+    internal convenience init(view: UIView, action: @escaping RotationAction) {
         self.init()
         self.referenceView = view
         self.rotationAction = action
@@ -246,7 +246,7 @@ extension UIRotationGestureRecognizer {
     /// This class is used as the target of the gesture recognizer action. It forwards the method call to the closure.
     internal class RotationGestureHandler: NSObject {
         let action: RotationAction
-            init(_ action: RotationAction) {
+            init(_ action: @escaping RotationAction) {
             self.action = action
         }
         func handleGesture(_ gestureRecognizer: UIRotationGestureRecognizer) {
@@ -276,7 +276,7 @@ extension UILongPressGestureRecognizer {
             }
         }
     }
-    internal convenience init(view: UIView, action: LongPressAction) {
+    internal convenience init(view: UIView, action: @escaping LongPressAction) {
         self.init()
         self.referenceView = view
         self.longPressAction = action
@@ -284,7 +284,7 @@ extension UILongPressGestureRecognizer {
     /// This class is used as the target of the gesture recognizer action. It forwards the method call to the closure.
     internal class LongPressGestureHandler: NSObject {
         let action: LongPressAction
-            init(_ action: LongPressAction) {
+            init(_ action: @escaping LongPressAction) {
             self.action = action
         }
         func handleGesture(_ gestureRecognizer: UILongPressGestureRecognizer) {
@@ -318,7 +318,7 @@ extension UISwipeGestureRecognizer {
             }
         }
     }
-    internal convenience init(view: UIView, action: SwipeAction) {
+    internal convenience init(view: UIView, action: @escaping SwipeAction) {
         self.init()
         self.referenceView = view
         self.swipeAction = action
@@ -326,7 +326,7 @@ extension UISwipeGestureRecognizer {
     /// This class is used as the target of the gesture recognizer action. It forwards the method call to the closure.
     internal class SwipeGestureHandler: NSObject {
         let action: SwipeAction
-            init(_ action: SwipeAction) {
+            init(_ action: @escaping SwipeAction) {
             self.action = action
         }
         func handleGesture(_ gestureRecognizer: UISwipeGestureRecognizer) {
@@ -359,7 +359,7 @@ extension UIScreenEdgePanGestureRecognizer {
             }
         }
     }
-    internal convenience init(view: UIView, action: ScreenEdgePanAction) {
+    internal convenience init(view: UIView, action: @escaping ScreenEdgePanAction) {
         self.init()
         self.referenceView = view
         self.screenEdgePanAction = action
@@ -368,7 +368,7 @@ extension UIScreenEdgePanGestureRecognizer {
     /// This class is used as the target of the gesture recognizer action. It forwards the method call to the closure.
     internal class ScreenEdgePanGestureHandler: NSObject {
         let action: ScreenEdgePanAction
-            init(_ action: ScreenEdgePanAction) {
+            init(_ action: @escaping ScreenEdgePanAction) {
             self.action = action
         }
         func handleGesture(_ gestureRecognizer: UIScreenEdgePanGestureRecognizer) {

--- a/C4/UI/View.swift
+++ b/C4/UI/View.swift
@@ -309,7 +309,7 @@ public class View: NSObject {
     /// ````
     /// - parameter action: A block of code to be executed when the receiver recognizes a tap gesture.
     /// - returns: A UITapGestureRecognizer that can be customized.
-    public func addTapGestureRecognizer(_ action: TapAction) -> UITapGestureRecognizer {
+    public func addTapGestureRecognizer(_ action: @escaping TapAction) -> UITapGestureRecognizer {
         let gestureRecognizer = UITapGestureRecognizer(view: self.view, action: action)
         self.view.addGestureRecognizer(gestureRecognizer)
         return gestureRecognizer
@@ -324,7 +324,7 @@ public class View: NSObject {
     /// }
     /// - parameter action: A block of code to be executed when the receiver recognizes a pan gesture.
     /// - returns: A UIPanGestureRecognizer that can be customized.
-    public func addPanGestureRecognizer(_ action: PanAction) -> UIPanGestureRecognizer {
+    public func addPanGestureRecognizer(_ action: @escaping PanAction) -> UIPanGestureRecognizer {
         let gestureRecognizer = UIPanGestureRecognizer(view: self.view, action: action)
         self.view.addGestureRecognizer(gestureRecognizer)
         return gestureRecognizer
@@ -339,7 +339,7 @@ public class View: NSObject {
     /// }
     /// - parameter action: A block of code to be executed when the receiver recognizes a pinch gesture.
     /// - returns: A UIPinchGestureRecognizer that can be customized.
-    public func addPinchGestureRecognizer(_ action: PinchAction) -> UIPinchGestureRecognizer {
+    public func addPinchGestureRecognizer(_ action: @escaping PinchAction) -> UIPinchGestureRecognizer {
         let gestureRecognizer = UIPinchGestureRecognizer(view: view, action: action)
         self.view.addGestureRecognizer(gestureRecognizer)
         return gestureRecognizer
@@ -355,7 +355,7 @@ public class View: NSObject {
     /// ````
     /// - parameter action: A block of code to be executed when the receiver recognizes a rotation gesture.
     /// - returns: A UIRotationGestureRecognizer that can be customized.
-    public func addRotationGestureRecognizer(_ action: RotationAction) -> UIRotationGestureRecognizer {
+    public func addRotationGestureRecognizer(_ action: @escaping RotationAction) -> UIRotationGestureRecognizer {
         let gestureRecognizer = UIRotationGestureRecognizer(view: view, action: action)
         self.view.addGestureRecognizer(gestureRecognizer)
         return gestureRecognizer
@@ -371,7 +371,7 @@ public class View: NSObject {
     /// ````
     /// - parameter action: A block of code to be executed when the receiver recognizes a longpress gesture.
     /// - returns: A UILongPressGestureRecognizer that can be customized.
-    public func addLongPressGestureRecognizer(_ action: LongPressAction) -> UILongPressGestureRecognizer {
+    public func addLongPressGestureRecognizer(_ action: @escaping LongPressAction) -> UILongPressGestureRecognizer {
         let gestureRecognizer = UILongPressGestureRecognizer(view: view, action: action)
         self.view.addGestureRecognizer(gestureRecognizer)
         return gestureRecognizer
@@ -387,7 +387,7 @@ public class View: NSObject {
     /// ````
     /// - parameter action: A block of code to be executed when the receiver recognizes a swipe gesture.
     /// - returns: A UISwipeGestureRecognizer that can be customized.
-    public func addSwipeGestureRecognizer(_ action: SwipeAction) -> UISwipeGestureRecognizer {
+    public func addSwipeGestureRecognizer(_ action: @escaping SwipeAction) -> UISwipeGestureRecognizer {
         let gestureRecognizer = UISwipeGestureRecognizer(view: view, action: action)
         self.view.addGestureRecognizer(gestureRecognizer)
         return gestureRecognizer
@@ -402,7 +402,7 @@ public class View: NSObject {
     /// ````
     /// - parameter action: A block of code to be executed when the receiver recognizes a screen edge pan gesture.
     /// - returns: A UIScreenEdgePanGestureRecognizer that can be customized.
-    public func addScreenEdgePanGestureRecognizer(_ action: ScreenEdgePanAction) -> UIScreenEdgePanGestureRecognizer {
+    public func addScreenEdgePanGestureRecognizer(_ action: @escaping ScreenEdgePanAction) -> UIScreenEdgePanGestureRecognizer {
         let gestureRecognizer = UIScreenEdgePanGestureRecognizer(view: view, action: action)
         self.view.addGestureRecognizer(gestureRecognizer)
         return gestureRecognizer


### PR DESCRIPTION
Ok, I did some changes in latest version of swift3 branch to make it compatible with new Swift 3 projects.

Well, the update was a bit trivial and my C4 projects created from swift3 branch, are running well in iOS 9 and iOS 10.

Cheers,